### PR TITLE
Trigger a `remove` on last superset's model

### DIFF
--- a/backbone-paginated-collection.js
+++ b/backbone-paginated-collection.js
@@ -48,7 +48,9 @@ function updateNumPages() {
   // Test to see if we are past the last page, and if so,
   // move back. Return true so that we can test to see if
   // this happened.
-  if (this.getPage() >= totalPages) {
+  // We don't want this behaviour on an newly empty superset, as it
+  // prevent the remove event to be triggered
+  if (this.getPage() >= totalPages && this.superset().length > 0) {
     this.setPage(totalPages - 1);
     return true;
   }

--- a/index.js
+++ b/index.js
@@ -35,7 +35,9 @@ function updateNumPages() {
   // Test to see if we are past the last page, and if so,
   // move back. Return true so that we can test to see if
   // this happened.
-  if (this.getPage() >= totalPages) {
+  // We don't want this behaviour on an newly empty superset, as it
+  // prevent the remove event to be triggered
+  if (this.getPage() >= totalPages && this.superset().length > 0) {
     this.setPage(totalPages - 1);
     return true;
   }

--- a/test/test.js
+++ b/test/test.js
@@ -764,6 +764,23 @@ describe('PaginatedCollection', function() {
       assert(called);
     });
 
+    it('remove event on removing last model', function() {
+      var superset = new Backbone.Collection({ a:'a' });
+      var paginated = new PaginatedCollection(superset);
+      var model = superset.first();
+
+      var called = false;
+      paginated.on('remove', function(m, collection) {
+        assert(m === model);
+        assert(collection === paginated);
+        called = true;
+      });
+
+      superset.remove(model);
+
+      assert(called);
+    });
+
     it("no remove event when removing a model not on the current page", function() {
       var model = superset.last();
 


### PR DESCRIPTION
When the last item of a collection is removed, the `remove` event isn't fired by the paginated collection.

It's due to the fact that `updateNumPages` return true when the number of pages is 0, even if the superset is empty, and so `onAddRemove` return early instead of removing that last model from it's wrapped collection.

See this [reduced test-case on jsBin](http://jsbin.com/xuxavotowa/edit?html,js,output) 
